### PR TITLE
bump numpy version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,13 +12,13 @@
         <dependency>
             <groupId>org.bytedeco</groupId>
             <artifactId>numpy</artifactId>
-            <version>1.18.2-1.5.3</version>
+            <version>1.22.2-1.5.7</version>
         </dependency>
 
         <dependency>
             <groupId>org.bytedeco</groupId>
             <artifactId>numpy-platform</artifactId>
-            <version>1.18.2-1.5.3</version>
+            <version>1.22.2-1.5.7</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
To get this repo working at our recent hackathon, @axtimwalde needed to bump the numpy versions.  For details, see:
https://janelia-cellmap.github.io/cellmap-hackathon-blog/javacpp/java/python/2022/06/16/javacpp-embedded-python.html 